### PR TITLE
Add transport abstraction layer interfaces

### DIFF
--- a/transport/errors.go
+++ b/transport/errors.go
@@ -1,0 +1,42 @@
+package transport
+
+import "errors"
+
+// Common transport errors.
+var (
+	// ErrNotConnected indicates that the transport is not connected.
+	ErrNotConnected = errors.New("transport not connected")
+
+	// ErrAlreadyStarted indicates that the transport is already started.
+	ErrAlreadyStarted = errors.New("transport already started")
+
+	// ErrNotStarted indicates that the transport has not been started.
+	ErrNotStarted = errors.New("transport not started")
+
+	// ErrClientNotFound indicates that the specified client ID was not found.
+	ErrClientNotFound = errors.New("client not found")
+
+	// ErrInvalidConfig indicates that the provided configuration is invalid.
+	ErrInvalidConfig = errors.New("invalid configuration")
+
+	// ErrInvalidPort indicates that the provided port number is invalid.
+	ErrInvalidPort = errors.New("invalid port number")
+
+	// ErrInvalidAddress indicates that the provided address is invalid.
+	ErrInvalidAddress = errors.New("invalid address")
+
+	// ErrConnectionClosed indicates that the connection has been closed.
+	ErrConnectionClosed = errors.New("connection closed")
+
+	// ErrWriteTimeout indicates that a write operation timed out.
+	ErrWriteTimeout = errors.New("write timeout")
+
+	// ErrReadTimeout indicates that a read operation timed out.
+	ErrReadTimeout = errors.New("read timeout")
+
+	// ErrMessageTooLarge indicates that a message exceeds the maximum allowed size.
+	ErrMessageTooLarge = errors.New("message too large")
+
+	// ErrUnsupportedTransport indicates that the transport type is not supported.
+	ErrUnsupportedTransport = errors.New("unsupported transport type")
+)

--- a/transport/factory.go
+++ b/transport/factory.go
@@ -1,0 +1,204 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+)
+
+// Factory provides a way to create transport instances based on configuration.
+type Factory interface {
+	// CreateTransport creates a new server-side transport instance based on the provided configuration.
+	CreateTransport(config Config) (Transport, error)
+
+	// CreateClientTransport creates a new client-side transport instance based on the provided configuration.
+	CreateClientTransport(config Config) (ClientTransport, error)
+
+	// SupportedTypes returns a list of transport types supported by this factory.
+	SupportedTypes() []TransportType
+}
+
+// DefaultFactory is the default implementation of the Factory interface.
+// It supports creating transports based on the configuration type.
+type DefaultFactory struct {
+	// transportCreators maps transport types to their creation functions for server transports.
+	transportCreators map[TransportType]func(Config) (Transport, error)
+
+	// clientTransportCreators maps transport types to their creation functions for client transports.
+	clientTransportCreators map[TransportType]func(Config) (ClientTransport, error)
+}
+
+// NewDefaultFactory creates a new DefaultFactory instance.
+func NewDefaultFactory() *DefaultFactory {
+	return &DefaultFactory{
+		transportCreators:       make(map[TransportType]func(Config) (Transport, error)),
+		clientTransportCreators: make(map[TransportType]func(Config) (ClientTransport, error)),
+	}
+}
+
+// RegisterTransport registers a creator function for a specific transport type for server transports.
+func (f *DefaultFactory) RegisterTransport(transportType TransportType, creator func(Config) (Transport, error)) {
+	f.transportCreators[transportType] = creator
+}
+
+// RegisterClientTransport registers a creator function for a specific transport type for client transports.
+func (f *DefaultFactory) RegisterClientTransport(transportType TransportType, creator func(Config) (ClientTransport, error)) {
+	f.clientTransportCreators[transportType] = creator
+}
+
+// CreateTransport creates a new server-side transport instance based on the provided configuration.
+func (f *DefaultFactory) CreateTransport(config Config) (Transport, error) {
+	if config == nil {
+		return nil, ErrInvalidConfig
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	transportType := config.GetType()
+	creator, exists := f.transportCreators[transportType]
+	if !exists {
+		return nil, fmt.Errorf("unsupported transport type: %v", transportType)
+	}
+
+	return creator(config)
+}
+
+// CreateClientTransport creates a new client-side transport instance based on the provided configuration.
+func (f *DefaultFactory) CreateClientTransport(config Config) (ClientTransport, error) {
+	if config == nil {
+		return nil, ErrInvalidConfig
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	transportType := config.GetType()
+	creator, exists := f.clientTransportCreators[transportType]
+	if !exists {
+		return nil, fmt.Errorf("unsupported transport type: %v", transportType)
+	}
+
+	return creator(config)
+}
+
+// SupportedTypes returns a list of transport types supported by this factory.
+func (f *DefaultFactory) SupportedTypes() []TransportType {
+	types := make([]TransportType, 0, len(f.transportCreators))
+	for transportType := range f.transportCreators {
+		types = append(types, transportType)
+	}
+	return types
+}
+
+// Manager provides high-level transport management capabilities.
+type Manager interface {
+	// StartTransport starts a transport with the given configuration and returns the transport instance.
+	StartTransport(ctx context.Context, config Config) (Transport, error)
+
+	// StartClientTransport starts a client transport with the given endpoint and configuration.
+	StartClientTransport(ctx context.Context, endpoint string, config Config) (ClientTransport, error)
+
+	// StopTransport stops the specified transport.
+	StopTransport(ctx context.Context, transport Transport) error
+
+	// StopClientTransport stops the specified client transport.
+	StopClientTransport(ctx context.Context, clientTransport ClientTransport) error
+
+	// GetActiveTransports returns a list of currently active server transports.
+	GetActiveTransports() []Transport
+
+	// GetActiveClientTransports returns a list of currently active client transports.
+	GetActiveClientTransports() []ClientTransport
+}
+
+// DefaultManager is the default implementation of the Manager interface.
+type DefaultManager struct {
+	factory          Factory
+	activeTransports []Transport
+	activeClients    []ClientTransport
+}
+
+// NewDefaultManager creates a new DefaultManager instance with the given factory.
+func NewDefaultManager(factory Factory) *DefaultManager {
+	return &DefaultManager{
+		factory:          factory,
+		activeTransports: make([]Transport, 0),
+		activeClients:    make([]ClientTransport, 0),
+	}
+}
+
+// StartTransport starts a transport with the given configuration and returns the transport instance.
+func (m *DefaultManager) StartTransport(ctx context.Context, config Config) (Transport, error) {
+	transport, err := m.factory.CreateTransport(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := transport.Start(ctx, config); err != nil {
+		return nil, fmt.Errorf("failed to start transport: %w", err)
+	}
+
+	m.activeTransports = append(m.activeTransports, transport)
+	return transport, nil
+}
+
+// StartClientTransport starts a client transport with the given endpoint and configuration.
+func (m *DefaultManager) StartClientTransport(ctx context.Context, endpoint string, config Config) (ClientTransport, error) {
+	clientTransport, err := m.factory.CreateClientTransport(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := clientTransport.Start(ctx, endpoint, config); err != nil {
+		return nil, fmt.Errorf("failed to start client transport: %w", err)
+	}
+
+	m.activeClients = append(m.activeClients, clientTransport)
+	return clientTransport, nil
+}
+
+// StopTransport stops the specified transport.
+func (m *DefaultManager) StopTransport(ctx context.Context, transport Transport) error {
+	if err := transport.Stop(ctx); err != nil {
+		return err
+	}
+
+	// Remove from active transports
+	for i, t := range m.activeTransports {
+		if t == transport {
+			m.activeTransports = append(m.activeTransports[:i], m.activeTransports[i+1:]...)
+			break
+		}
+	}
+
+	return nil
+}
+
+// StopClientTransport stops the specified client transport.
+func (m *DefaultManager) StopClientTransport(ctx context.Context, clientTransport ClientTransport) error {
+	if err := clientTransport.Stop(ctx); err != nil {
+		return err
+	}
+
+	// Remove from active clients
+	for i, c := range m.activeClients {
+		if c == clientTransport {
+			m.activeClients = append(m.activeClients[:i], m.activeClients[i+1:]...)
+			break
+		}
+	}
+
+	return nil
+}
+
+// GetActiveTransports returns a list of currently active server transports.
+func (m *DefaultManager) GetActiveTransports() []Transport {
+	return append([]Transport(nil), m.activeTransports...)
+}
+
+// GetActiveClientTransports returns a list of currently active client transports.
+func (m *DefaultManager) GetActiveClientTransports() []ClientTransport {
+	return append([]ClientTransport(nil), m.activeClients...)
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,0 +1,239 @@
+// Package transport provides abstractions for different transport layers in OCPP implementations.
+// It defines interfaces that can be implemented by various transport mechanisms such as WebSocket,
+// Redis, or other messaging systems to enable flexible OCPP communication.
+package transport
+
+import (
+	"context"
+	"crypto/tls"
+	"time"
+)
+
+// TransportType represents the type of transport implementation.
+type TransportType int
+
+const (
+	// WebSocketTransport indicates a WebSocket-based transport.
+	WebSocketTransport TransportType = iota
+	// RedisTransport indicates a Redis-based transport.
+	RedisTransport
+)
+
+// String returns the string representation of the transport type.
+func (t TransportType) String() string {
+	switch t {
+	case WebSocketTransport:
+		return "websocket"
+	case RedisTransport:
+		return "redis"
+	default:
+		return "unknown"
+	}
+}
+
+// Config represents the configuration interface for transport implementations.
+// Each transport type should implement this interface with their specific configuration.
+type Config interface {
+	// GetType returns the transport type this configuration is for.
+	GetType() TransportType
+	// Validate checks if the configuration is valid and returns an error if not.
+	Validate() error
+}
+
+// MessageHandler is a function that processes incoming messages.
+// It receives the client ID and the message data, and returns an error if processing fails.
+type MessageHandler func(clientID string, data []byte) error
+
+// ConnectionHandler is a function that handles connection events.
+// It receives the client ID of the connecting client.
+type ConnectionHandler func(clientID string)
+
+// DisconnectionHandler is a function that handles disconnection events.
+// It receives the client ID and the error that caused the disconnection (if any).
+type DisconnectionHandler func(clientID string, err error)
+
+// ErrorHandler is a function that handles transport-level errors.
+// It receives the client ID (if available) and the error that occurred.
+type ErrorHandler func(clientID string, err error)
+
+// Transport defines the interface for server-side transport implementations.
+// This interface abstracts the underlying communication mechanism and provides
+// a unified API for OCPP message exchange in a server context where multiple
+// clients can connect.
+type Transport interface {
+	// Start initializes and starts the transport with the given configuration.
+	// It should begin listening for connections and be ready to handle messages.
+	Start(ctx context.Context, config Config) error
+
+	// Stop gracefully shuts down the transport, closing all connections.
+	// It should ensure all pending operations are completed or cancelled.
+	Stop(ctx context.Context) error
+
+	// IsRunning returns true if the transport is currently running and accepting connections.
+	IsRunning() bool
+
+	// Write sends data to a specific client identified by clientID.
+	// Returns an error if the client is not connected or if sending fails.
+	Write(clientID string, data []byte) error
+
+	// WriteToAll broadcasts data to all connected clients.
+	// Returns a map of clientID to error for any failed sends.
+	WriteToAll(data []byte) map[string]error
+
+	// GetConnectedClients returns a slice of currently connected client IDs.
+	GetConnectedClients() []string
+
+	// IsClientConnected checks if a specific client is currently connected.
+	IsClientConnected(clientID string) bool
+
+	// SetMessageHandler sets the handler for incoming messages.
+	// The handler will be called for each message received from any client.
+	SetMessageHandler(handler MessageHandler)
+
+	// SetConnectionHandler sets the handler for new client connections.
+	SetConnectionHandler(handler ConnectionHandler)
+
+	// SetDisconnectionHandler sets the handler for client disconnections.
+	SetDisconnectionHandler(handler DisconnectionHandler)
+
+	// SetErrorHandler sets the handler for transport-level errors.
+	SetErrorHandler(handler ErrorHandler)
+
+	// Errors returns a channel that receives transport-level errors.
+	// This provides an alternative to SetErrorHandler for error handling.
+	Errors() <-chan error
+}
+
+// ClientTransport defines the interface for client-side transport implementations.
+// This interface abstracts the underlying communication mechanism for a single
+// client connecting to a server.
+type ClientTransport interface {
+	// Start establishes a connection to the server at the given endpoint.
+	// The endpoint format depends on the transport implementation.
+	Start(ctx context.Context, endpoint string, config Config) error
+
+	// Stop closes the connection to the server.
+	// It should ensure all pending operations are completed or cancelled.
+	Stop(ctx context.Context) error
+
+	// IsConnected returns true if the client is currently connected to the server.
+	IsConnected() bool
+
+	// Write sends data to the connected server.
+	// Returns an error if not connected or if sending fails.
+	Write(data []byte) error
+
+	// SetMessageHandler sets the handler for incoming messages from the server.
+	SetMessageHandler(handler func(data []byte) error)
+
+	// SetDisconnectionHandler sets the handler for disconnection events.
+	// The handler receives the error that caused the disconnection (if any).
+	SetDisconnectionHandler(handler func(err error))
+
+	// SetReconnectionHandler sets the handler for successful reconnection events.
+	// This is called when the client successfully reconnects after a disconnection.
+	SetReconnectionHandler(handler func())
+
+	// SetErrorHandler sets the handler for transport-level errors.
+	SetErrorHandler(handler func(err error))
+
+	// Errors returns a channel that receives transport-level errors.
+	// This provides an alternative to SetErrorHandler for error handling.
+	Errors() <-chan error
+}
+
+// WebSocketConfig contains configuration options for WebSocket transport.
+type WebSocketConfig struct {
+	// Port is the port number to listen on (server) or connect to (client).
+	Port int
+	// ListenPath is the HTTP path to listen on (server only).
+	ListenPath string
+	// TLSConfig contains TLS configuration for secure connections.
+	TLSConfig *tls.Config
+	// ReadTimeout is the timeout for read operations.
+	ReadTimeout time.Duration
+	// WriteTimeout is the timeout for write operations.
+	WriteTimeout time.Duration
+	// HandshakeTimeout is the timeout for the WebSocket handshake.
+	HandshakeTimeout time.Duration
+	// MaxMessageSize is the maximum size of a message in bytes.
+	MaxMessageSize int64
+	// CheckOrigin is used to check the origin of upgrade requests.
+	CheckOrigin func(origin string) bool
+}
+
+// GetType returns WebSocketTransport.
+func (c *WebSocketConfig) GetType() TransportType {
+	return WebSocketTransport
+}
+
+// Validate checks if the WebSocket configuration is valid.
+func (c *WebSocketConfig) Validate() error {
+	if c.Port <= 0 || c.Port > 65535 {
+		return ErrInvalidPort
+	}
+	if c.ListenPath == "" {
+		c.ListenPath = "/"
+	}
+	if c.ReadTimeout <= 0 {
+		c.ReadTimeout = 30 * time.Second
+	}
+	if c.WriteTimeout <= 0 {
+		c.WriteTimeout = 10 * time.Second
+	}
+	if c.HandshakeTimeout <= 0 {
+		c.HandshakeTimeout = 10 * time.Second
+	}
+	if c.MaxMessageSize <= 0 {
+		c.MaxMessageSize = 32 * 1024 // 32KB default
+	}
+	return nil
+}
+
+// RedisConfig contains configuration options for Redis transport.
+type RedisConfig struct {
+	// Addr is the Redis server address in host:port format.
+	Addr string
+	// Password is the Redis server password (optional).
+	Password string
+	// DB is the Redis database number to use.
+	DB int
+	// ChannelPrefix is the prefix for Redis channels used for communication.
+	ChannelPrefix string
+	// ClientTimeout is the timeout for Redis client operations.
+	ClientTimeout time.Duration
+	// ConnectionPoolSize is the size of the Redis connection pool.
+	ConnectionPoolSize int
+	// RetryAttempts is the number of retry attempts for failed operations.
+	RetryAttempts int
+	// RetryDelay is the delay between retry attempts.
+	RetryDelay time.Duration
+}
+
+// GetType returns RedisTransport.
+func (c *RedisConfig) GetType() TransportType {
+	return RedisTransport
+}
+
+// Validate checks if the Redis configuration is valid.
+func (c *RedisConfig) Validate() error {
+	if c.Addr == "" {
+		return ErrInvalidAddress
+	}
+	if c.ChannelPrefix == "" {
+		c.ChannelPrefix = "ocpp"
+	}
+	if c.ClientTimeout <= 0 {
+		c.ClientTimeout = 30 * time.Second
+	}
+	if c.ConnectionPoolSize <= 0 {
+		c.ConnectionPoolSize = 10
+	}
+	if c.RetryAttempts < 0 {
+		c.RetryAttempts = 3
+	}
+	if c.RetryDelay <= 0 {
+		c.RetryDelay = time.Second
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Introduces a new `transport` package with comprehensive interface definitions for OCPP transport abstraction
- Defines `Transport` and `ClientTransport` interfaces to support multiple transport mechanisms (WebSocket, Redis)
- Includes configuration types, factory patterns, and error handling for transport implementations
- Provides full godoc documentation for all exported types and methods

## Key Components
- **Core Interfaces**: `Transport` (server-side) and `ClientTransport` (client-side) abstractions
- **Configuration**: `WebSocketConfig` and `RedisConfig` implementations with validation
- **Factory Pattern**: `Factory` and `Manager` interfaces for transport creation and lifecycle management
- **Error Handling**: Comprehensive error definitions for transport-specific failures

## Implementation Details
- Generic interfaces designed to work with both WebSocket and Redis transports
- No modifications to existing code - pure interface definition
- Maintains backward compatibility with existing WebSocket implementation
- Follows Go conventions and includes comprehensive documentation

## Test Status
- Package compiles successfully (`go build ./transport`)
- Core OCPP tests continue to pass (`go test ./ocpp1.6_test`)
- No breaking changes to existing functionality

This establishes the foundation for Step 2 (WebSocket adapter) and Step 3 (Redis implementation) of the transport abstraction plan.

🤖 Generated with [Claude Code](https://claude.ai/code)